### PR TITLE
Add preference to control forward/backward animations

### DIFF
--- a/Arc 2.0/Chrome CSS/animations.css
+++ b/Arc 2.0/Chrome CSS/animations.css
@@ -559,14 +559,16 @@ menupopup *, menuitem *,
     transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.1) 0.1s !important;
   }
 
-@media (-moz-pref("arc-page-animations")) {
+@media (-moz-pref("arc-previous-page-animation")) {
 
   /* Previous animation*/
   .browserStack:has(#historySwipeAnimationPreviousArrow:not([style="translate: none;"])) browser{
     scale: 0.95 !important;
     transform: translateX(3%) !important;
   }
+}
   
+@media (-moz-pref("arc-next-page-animation")) {
   /* Next animation*/
   .browserStack:has(#historySwipeAnimationNextArrow:not([style="translate: none;"])) browser{
     scale: 0.95 !important;

--- a/preferences.json
+++ b/preferences.json
@@ -167,8 +167,14 @@
   },
   {
     "type": "checkbox",
-    "label": "Enable Previous/Next page animations",
-    "property": "arc-page-animations",
+    "label": "Enable Previous page animations",
+    "property": "arc-previous-page-animation",
+    "default": true
+  },
+  {
+    "type": "checkbox",
+    "label": "Enable Next page animations",
+    "property": "arc-next-page-animation",
     "default": true
   },
   {


### PR DESCRIPTION
I dislike the animations for navigating forward and backward, so figured I'd add a simple preference to toggle this behavior. As it defaults to enabled, there shouldn't be any change in functionality.

Tested on latest Zen 1.16.4b with Sine v2.2.3.
