### PR TITLE
Removed redundant transition and always-on GPU layer

### DIFF
--- a/Arc 2.0/Chrome CSS/URLbar.css
+++ b/Arc 2.0/Chrome CSS/URLbar.css
@@ -175,7 +175,16 @@
 /* ------------------ URL Bar BG ------------------ */
 
 .browserStack {
-  transition: all 0.3s cubic-bezier(0.175, 0.385, 0.12, 1) !important;
+  filter: none !important;
+  opacity: 1 !important;
+  transition:
+    filter 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.35),
+    opacity 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.35),
+    scale 0.25s cubic-bezier(0.175, 0.885, 0.32, 1) !important;
+}
+
+#browser:has(#urlbar[open]) .browserStack {
+  scale: 1 !important;
 }
 
 @media not (-moz-pref("arc.urlbar.background")){
@@ -184,16 +193,6 @@
     filter: brightness(50%) blur(30px) saturate(145%) !important;
     opacity: 1 !important;
   }
-}
-
-.browserStack:not(:has(#urlbar[open])) {
-  filter: none !important;
-  opacity: 1 !important;
-  scale: 1 !important;
-  transition:
-    filter 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.35),
-    opacity 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.35),
-    scale 0.25s cubic-bezier(0.175, 0.885, 0.32, 1) !important;
 }
 
 .urlbarView-row {


### PR DESCRIPTION
The urlbar background blur effect used three separate rules that conflicted with each other, including a `transition: all` and a `:not(:has())` reset rule that were doing the same job twice.

Consolidated into a single base rule with explicit transitions, and scoped the GPU layer promotion to only when the urlbar is open.

### Verified before and after with UFO refresh rate test.
Given that my refresh rate is 60hz, I also did test with a [youtube video](https://www.youtube.com/watch?v=gmHaa5pvpVc&pp=ygUKNjBmcHMgdGVzdA%3D%3D) at 60 fps, frame drops are immediately perceptible without the patch. 

**Old**
<img width="1916" height="1034" alt="image" src="https://github.com/user-attachments/assets/5c38d3e7-890b-4a87-b3c8-652d11ee785e" />

**Patched**
<img width="1919" height="1043" alt="image" src="https://github.com/user-attachments/assets/e88fd810-156f-4183-901f-06b514db655a" />
