### PR TITLE
Add standalone option for tabbox border radius

### DIFF
--- a/modules/chrome/borders.css
+++ b/modules/chrome/borders.css
@@ -97,11 +97,26 @@ body > hbox {
 }
 
 :root[zen-right-side="true"]:not([zen-compact-mode="true"]):not([inDOMFullscreen="true"]) #zen-tabbox-wrapper {
-  border-radius: var(--arc-border-radius, 12px) !important;
+  border-radius: var(--arc-tabbox-border-radius, 12px) !important;
 }
 
 :root:not([zen-right-side="true"]):not([zen-compact-mode="true"]):not([inDOMFullscreen="true"]) #zen-tabbox-wrapper {
-  border-radius: var(--arc-border-radius, 12px) !important;
+  border-radius: var(--arc-tabbox-border-radius, 12px) !important;
+:root[zen-right-side="true"]:not(
+    [zen-compact-mode="true"],
+    [inDOMFullscreen="true"]
+  )
+  #zen-tabbox-wrapper {
+  border-radius: var(--arc-tabbox-border-radius, 12px) !important;
+}
+
+:root:not(
+    [zen-right-side="true"],
+    [zen-compact-mode="true"],
+    [inDOMFullscreen="true"]
+  )
+  #zen-tabbox-wrapper {
+  border-radius: var(--arc-tabbox-border-radius, 12px) !important;
 }
 
 /* ADD WEBVIEW BORDER RADIUS TO CHILDREN ELEMENTS OF TABBOX */
@@ -115,12 +130,12 @@ body > hbox {
 }
 
 :root:has([zen-compact-mode="true"]):has([sizemode="normal"]):has(#zen-appcontent-navbar-wrapper[zen-has-hover="false"]) #zen-tabbox-wrapper {
-  border-radius: var(--arc-border-radius, 12px) !important;
+  border-radius: var(--arc-tabbox-border-radius, 12px) !important;
 }
 
 :root:has([zen-compact-mode="true"]):has([sizemode="normal"]):has(#zen-appcontent-navbar-wrapper[zen-has-hover="false"]) #tabbrowser-tabbox,
 :root:has([zen-compact-mode="true"]):has([sizemode="normal"]):has(#zen-appcontent-navbar-wrapper[zen-has-hover="false"]) #tabbrowser-tabbox > * {
-  border-radius: var(--arc-border-radius, 12px) !important;
+  border-radius: var(--arc-tabbox-border-radius, 12px) !important;
 }
 
 :root[inDOMFullscreen="true"] #tabbrowser-tabpanels {

--- a/preferences.json
+++ b/preferences.json
@@ -59,6 +59,13 @@
   },
   {
     "type": "string",
+    "label": "Custom *border radius* for tab box",
+    "property": "arc-tabbox-border-radius",
+    "defaultValue": "12px",
+    "placeholder": "12px"
+  },
+  {
+    "type": "string",
     "value": "number",
     "label": "Edit Zen window margin width between web-view and border (~enter value between 0 to 12; value set here will be overriden by whatever mode is for *No Gaps*~).",
     "property": "zen.theme.content-element-separation"


### PR DESCRIPTION
Allow setting `border-radius` for `tabbox` separately to avoid an overly wide `border-width` on `tabbox`.

Without this option, and with `arc-border-radius` set to the default value (`12px`) , it appears as shown following.

<img width="3381" height="2073" alt="image" src="https://github.com/user-attachments/assets/513f4375-2e54-4f30-8f5c-1eca5df2468b" />

After (with the new property `arc-tabbox-border-radius` set to `0px`)

<img width="3380" height="2076" alt="image" src="https://github.com/user-attachments/assets/bb11cffb-8884-43c8-a8e1-01cdf21fabbf" />

