### PR TITLE
Fix icons being clipped by rounded corners

### DIFF
--- a/modules/chrome/general.css
+++ b/modules/chrome/general.css
@@ -27,6 +27,15 @@ browser {
 :root {
   --attention-dot-color: transparent !important; /* remove attention dot */
   --zen-themed-toolbar-bg-transparent: transparent !important; /* fix for transparency */
+
+  /* Fix icon border radius */
+  .tab-icon-image,
+  .toolbarbutton-icon,
+  .toolbarbutton-animatable-iamge,
+  #downloads-indicator-icon {
+    border-radius: 0 !important;
+    overflow: visible !important;
+  }
 }
 
 /* Increased blur for Menus */


### PR DESCRIPTION
This patch fixes an issue where some icons were clipped by rounded corners caused by plugin styles.

The problem is resolved by setting overflow: visible and border-radius: 0px.

Before and after screenshots are shown below.

Before

<img width="53" height="50" alt="image" src="https://github.com/user-attachments/assets/68ade4bf-e67c-4603-a937-d7c6ea1a7a0d" />
<img width="65" height="50" alt="image" src="https://github.com/user-attachments/assets/d0b4dc15-51cf-45a6-b5c5-ada0d2b677b9" />
<img width="52" height="42" alt="image" src="https://github.com/user-attachments/assets/b12dc1ae-6129-4758-866a-d411d5fec55d" />

After

<img width="53" height="50" alt="image" src="https://github.com/user-attachments/assets/dbbec09d-3a09-459c-8432-ad120be11c88" />
<img width="65" height="50" alt="image" src="https://github.com/user-attachments/assets/7b22533e-063e-4898-a117-6533841bf4ad" />
<img width="41" height="41" alt="image" src="https://github.com/user-attachments/assets/e95fefde-94b3-4471-8c6d-4a079611fa0c" />
